### PR TITLE
Changed (require…) to (:require…)

### DIFF
--- a/src/popen.clj
+++ b/src/popen.clj
@@ -1,7 +1,7 @@
 (ns ^{:doc "Subprocess library"
       :author "Miki Tebeka <miki.tebeka@gmail.com>"}
   popen
-  (require [clojure.java.io :as io]))
+  (:require [clojure.java.io :as io]))
 
 (defn popen
   "Open a sub process, return the subprocess


### PR DESCRIPTION
In org.clojure/clojure "1.9.0-beta2", Clojure.spec complains that the call to ns is invalid. The error message is extremely unclear, but I'm pretty sure the problem is a missing colon before "require". This appears to be a common error exposed by Clojure.spec: https://clojurians-log.clojureverse.org/clojure-spec/2017-05-02.html This error causes any attempt to (:require [popen]) from another namespace to fail to compile.